### PR TITLE
Fix Buffer Slicing in `RTCM3.Filter()` Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ while (true)
             Console.WriteLine($"RTCM_{message.MessageType} Encode method is not implemented.");
         }
     }
-    pipeReader.AdvanceTo(buffer.Start, buffer.End); // important
+    pipeReader.AdvanceTo(buffer.Start, buffer.Start); // important
     if (rs.IsCompleted)
     {
         break;

--- a/RTCM3/RTCM3.cs
+++ b/RTCM3/RTCM3.cs
@@ -90,8 +90,6 @@ namespace RTCM3
             SequenceReader<byte> reader = new(buffer);
             if (reader.TryAdvanceTo((byte)Preamble, false))
             {
-                long Consumed = reader.Consumed;
-                buffer = buffer.Slice(Consumed);
                 if (reader.Remaining < 3)
                 {
                     return null;
@@ -107,22 +105,22 @@ namespace RTCM3
                     try
                     {
                         result = new RTCM3(buffer);
-                        buffer = buffer.Slice(len, 0);
+                        buffer = buffer.Slice(len);
                     }
                     catch
                     {
                         result = null;
-                        buffer = buffer.Slice(1, 0);
+                        buffer = buffer.Slice(1);
                     }
                 }
                 else
                 {
-                    buffer = buffer.Slice(3, 0);
+                    buffer = buffer.Slice(3);
                 }
             }
             else
             {
-                buffer = buffer.Slice(buffer.Length, 0);
+                buffer = buffer.Slice(buffer.Length);
             }
             return result;
         }


### PR DESCRIPTION
This pull request addresses an issue in the `RTCM3.Filter()` method where the buffer was incorrectly sliced to a length of zero. This caused the decoding process to halt after the first message when using `ReadOnlySequence<byte>` directly, as no data remained for subsequent messages.

Changes Made
------------

-   **Corrected Buffer Slicing**: Updated the buffer slicing from `buffer.Slice(len, 0);` to `buffer.Slice(len);` to ensure that the remaining unprocessed data is preserved for further decoding.
-   **Consistent Buffer Handling**: Adjusted other instances in the code where the buffer was set to a length of zero to prevent similar issues.

Testing
-------

-   **Unit Tests**: All unit tests were run successfully, confirming that the changes do not introduce any regressions.
-   **File Sources**: The previous implementation worked fine with file sources, and this functionality remains unaffected.
-   **Direct `ReadOnlySequence<byte>` Usage**: The fix resolves the problem when using `ReadOnlySequence<byte>` directly, allowing for proper decoding of multiple RTCM3 messages within the same frame.

resolves #1 